### PR TITLE
Fix extension association

### DIFF
--- a/AVIFQuickLook/Info.plist
+++ b/AVIFQuickLook/Info.plist
@@ -12,6 +12,7 @@
 			<key>LSItemContentTypes</key>
 			<array>
 				<string>public.avif</string>
+				<string>dyn.ah62d4rv4ge80c7xmq2</string>
 			</array>
 		</dict>
 	</array>


### PR DESCRIPTION
In some system configurations, `public.avif` UTI (universal type identifier) doesn't exist. You can specify the extension explicitly using an arcane thing called "dynamic UTI", which is what I did here. Details: https://alastairs-place.net/blog/2012/06/06/utis-are-better-than-you-think-and-heres-why/